### PR TITLE
feat: Add final suite of validation analyzers

### DIFF
--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/CountSizeReferenceExistenceAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/CountSizeReferenceExistenceAnalyzerTests.cs
@@ -1,0 +1,74 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class CountSizeReferenceExistenceAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public Type CountType { get; set; }
+        public int CountSize { get; set; } = -1;
+        public string CountSizeReference { get; set; }
+    }
+}";
+
+        [Fact]
+        public async Task CountSizeReference_ToExistingProperty_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    public int MyCount { get; set; }
+
+    [SerializeCollection(CountSizeReference = ""MyCount"")]
+    public List<int> MyList { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<CountSizeReferenceExistenceAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task CountSizeReference_ToNonExistentProperty_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    [SerializeCollection(CountSizeReference = ""NonExistentCount"")]
+    public List<int> {|FS0006:MyList|} { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<CountSizeReferenceExistenceAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/CountSizeReferenceTypeAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/CountSizeReferenceTypeAnalyzerTests.cs
@@ -1,0 +1,102 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class CountSizeReferenceTypeAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public Type CountType { get; set; }
+        public int CountSize { get; set; } = -1;
+        public string CountSizeReference { get; set; }
+    }
+}";
+
+        [Fact]
+        public async Task CountSizeReference_ToIntegerProperty_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    public int MyCount { get; set; }
+
+    [SerializeCollection(CountSizeReference = ""MyCount"")]
+    public List<int> MyList { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<CountSizeReferenceTypeAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task CountSizeReference_ToByteProperty_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    public byte MyCount { get; set; }
+
+    [SerializeCollection(CountSizeReference = ""MyCount"")]
+    public List<int> MyList { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<CountSizeReferenceTypeAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task CountSizeReference_ToNonIntegerProperty_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    public string {|FS0007:MyCount|} { get; set; }
+
+    [SerializeCollection(CountSizeReference = ""MyCount"")]
+    public List<int> MyList { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<CountSizeReferenceTypeAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/DuplicatePolymorphicTypeIdAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/DuplicatePolymorphicTypeIdAnalyzerTests.cs
@@ -1,0 +1,74 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class DuplicatePolymorphicTypeIdAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+    public class PolymorphicOptionAttribute : Attribute
+    {
+        public PolymorphicOptionAttribute(int id, Type type) { }
+    }
+
+    public class BaseType { }
+    public class DerivedType1 : BaseType { }
+    public class DerivedType2 : BaseType { }
+}";
+
+        [Fact]
+        public async Task UniqueTypeIds_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+
+class MyData
+{
+    [PolymorphicOption(1, typeof(DerivedType1))]
+    [PolymorphicOption(2, typeof(DerivedType2))]
+    public BaseType MyProperty { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<DuplicatePolymorphicTypeIdAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task DuplicateTypeIds_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+
+class MyData
+{
+    [PolymorphicOption(1, typeof(DerivedType1))]
+    [{|FS0010:PolymorphicOption(1, typeof(DerivedType2))|}]
+    public BaseType MyProperty { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<DuplicatePolymorphicTypeIdAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/IncompatibleTypeAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/IncompatibleTypeAnalyzerTests.cs
@@ -86,5 +86,92 @@ public partial class CompatibleType : ISerializable<CompatibleType>
 
             await test.RunAsync();
         }
+
+        [Fact]
+        public async Task HashSetOfPrimitives_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+[GenerateSerializer]
+public partial class MyData
+{
+    public HashSet<int> MySet { get; set; }
+}";
+            var test = new CSharpAnalyzerTest<IncompatibleTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { GenerateSerializerAttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task QueueOfSerializableType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+[GenerateSerializer]
+public partial class MyData
+{
+    public Queue<CompatibleType> MyQueue { get; set; }
+}
+
+[GenerateSerializer]
+public partial class CompatibleType { }
+";
+            var test = new CSharpAnalyzerTest<IncompatibleTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { GenerateSerializerAttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task StackOfIncompatibleType_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+[GenerateSerializer]
+public partial class MyData
+{
+    public Stack<IncompatibleType> {|FS0002:MyStack|} { get; set; }
+}
+
+public class IncompatibleType { }
+";
+            var test = new CSharpAnalyzerTest<IncompatibleTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { GenerateSerializerAttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task IEnumerableOfPrimitives_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+[GenerateSerializer]
+public partial class MyData
+{
+    public IEnumerable<int> MyEnumerable { get; set; }
+}";
+            var test = new CSharpAnalyzerTest<IncompatibleTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { GenerateSerializerAttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
     }
 }

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidCountTypeAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidCountTypeAnalyzerTests.cs
@@ -1,0 +1,62 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class InvalidCountTypeAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+using System.Collections.Generic;
+
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public Type CountType { get; set; }
+    }
+}";
+
+        [Fact]
+        public async Task ValidIntCountType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [SerializeCollection(CountType = typeof(int))] public int[] MyList { get; set; } }";
+            await new CSharpAnalyzerTest<InvalidCountTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task ValidByteCountType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [SerializeCollection(CountType = typeof(byte))] public int[] MyList { get; set; } }";
+            await new CSharpAnalyzerTest<InvalidCountTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task InvalidStringCountType_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [{|FS0012:SerializeCollection(CountType = typeof(string))|}] public int[] MyList { get; set; } }";
+            await new CSharpAnalyzerTest<InvalidCountTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidPolymorphicOptionContextAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidPolymorphicOptionContextAnalyzerTests.cs
@@ -1,0 +1,110 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class InvalidPolymorphicOptionContextAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+
+namespace FourSer.Contracts
+{
+    public enum PolymorphicMode { None, SingleTypeId, IndividualTypeIds }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public PolymorphicMode PolymorphicMode { get; set; } = PolymorphicMode.None;
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializePolymorphicAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+    public class PolymorphicOptionAttribute : Attribute
+    {
+        public PolymorphicOptionAttribute(int id, Type type) { }
+    }
+
+    public class BaseType { }
+    public class DerivedType : BaseType { }
+}";
+
+        [Fact]
+        public async Task PolymorphicOption_WithSerializePolymorphic_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    [SerializePolymorphic]
+    [PolymorphicOption(1, typeof(DerivedType))]
+    public BaseType MyProperty { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidPolymorphicOptionContextAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PolymorphicOption_WithSerializeCollection_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    [SerializeCollection(PolymorphicMode = PolymorphicMode.IndividualTypeIds)]
+    [PolymorphicOption(1, typeof(DerivedType))]
+    public List<BaseType> MyList { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidPolymorphicOptionContextAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PolymorphicOption_WithoutContext_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    [PolymorphicOption(1, typeof(DerivedType))]
+    public BaseType {|FS0008:MyProperty|} { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidPolymorphicOptionContextAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidPolymorphicTypeAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidPolymorphicTypeAnalyzerTests.cs
@@ -1,0 +1,128 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class InvalidPolymorphicTypeAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public class GenerateSerializerAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+    public class PolymorphicOptionAttribute : Attribute
+    {
+        public PolymorphicOptionAttribute(int id, Type type) { }
+    }
+
+    [GenerateSerializer]
+    public partial class BaseType { }
+
+    [GenerateSerializer]
+    public partial class DerivedType : BaseType { }
+
+    [GenerateSerializer]
+    public partial class UnrelatedType { }
+
+    public class AssignableButNotSerializable : BaseType { }
+}";
+
+        [Fact]
+        public async Task PolymorphicOption_WithAssignableType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+
+class MyData
+{
+    [PolymorphicOption(1, typeof(DerivedType))]
+    public BaseType MyProperty { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidPolymorphicTypeAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PolymorphicOption_WithoutGenerateSerializer_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+
+class MyData
+{
+    [{|FS0016:PolymorphicOption(1, typeof(AssignableButNotSerializable))|}]
+    public BaseType MyProperty { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidPolymorphicTypeAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PolymorphicOption_WithSameType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+
+class MyData
+{
+    [PolymorphicOption(1, typeof(BaseType))]
+    public BaseType MyProperty { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidPolymorphicTypeAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PolymorphicOption_WithUnassignableType_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+
+class MyData
+{
+    [{|FS0009:PolymorphicOption(1, typeof(UnrelatedType))|}]
+    public BaseType MyProperty { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidPolymorphicTypeAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidSerializeCollectionTargetAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidSerializeCollectionTargetAnalyzerTests.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class InvalidSerializeCollectionTargetAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public Type CountType { get; set; }
+        public int CountSize { get; set; } = -1;
+        public string CountSizeReference { get; set; }
+    }
+}";
+
+        [Fact]
+        public async Task SerializeCollection_OnCollectionType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+
+class MyData
+{
+    [SerializeCollection]
+    public List<int> MyList { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidSerializeCollectionTargetAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task SerializeCollection_OnNonCollectionType_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+
+class MyData
+{
+    [SerializeCollection]
+    public int {|FS0005:MyValue|} { get; set; }
+}";
+
+            var test = new CSharpAnalyzerTest<InvalidSerializeCollectionTargetAnalyzer, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { AttributeSource, testCode },
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            };
+            await test.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidTypeIdTypeAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/InvalidTypeIdTypeAnalyzerTests.cs
@@ -1,0 +1,62 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class InvalidTypeIdTypeAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializePolymorphicAttribute : Attribute { public Type TypeIdType { get; set; } }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute { public Type TypeIdType { get; set; } }
+
+    public enum MyEnum { A, B }
+}";
+
+        [Fact]
+        public async Task ValidIntegerTypeIdType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [SerializePolymorphic(TypeIdType = typeof(int))] public object MyProp { get; set; } }";
+            await new CSharpAnalyzerTest<InvalidTypeIdTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task ValidEnumTypeIdType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [SerializeCollection(TypeIdType = typeof(MyEnum))] public object MyProp { get; set; } }";
+            await new CSharpAnalyzerTest<InvalidTypeIdTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task InvalidStringTypeIdType_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [{|FS0013:SerializePolymorphic(TypeIdType = typeof(string))|}] public object MyProp { get; set; } }";
+            await new CSharpAnalyzerTest<InvalidTypeIdTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/MismatchedTypeIdPropertyTypeAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/MismatchedTypeIdPropertyTypeAnalyzerTests.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class MismatchedTypeIdPropertyTypeAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+using System.Collections.Generic;
+
+namespace FourSer.Contracts
+{
+    public enum PolymorphicMode { None, SingleTypeId, IndividualTypeIds }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public PolymorphicMode PolymorphicMode { get; set; } = PolymorphicMode.None;
+        public string TypeIdProperty { get; set; }
+        public Type TypeIdType { get; set; }
+    }
+}";
+
+        [Fact]
+        public async Task MatchingTypes_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+class MyData { [SerializeCollection(PolymorphicMode = PolymorphicMode.SingleTypeId, TypeIdProperty = ""P"", TypeIdType = typeof(byte))] public List<int> L {get;set;} public byte P {get;set;} }";
+            await new CSharpAnalyzerTest<MismatchedTypeIdPropertyTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task DefaultIntType_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+class MyData { [SerializeCollection(PolymorphicMode = PolymorphicMode.SingleTypeId, TypeIdProperty = ""P"")] public List<int> L {get;set;} public int P {get;set;} }";
+            await new CSharpAnalyzerTest<MismatchedTypeIdPropertyTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task MismatchedTypes_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+class MyData { [SerializeCollection(PolymorphicMode = PolymorphicMode.SingleTypeId, TypeIdProperty = ""P"", TypeIdType = typeof(byte))] public List<int> L {get;set;} public int {|FS0015:P|} {get;set;} }";
+            await new CSharpAnalyzerTest<MismatchedTypeIdPropertyTypeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/MissingTypeIdPropertyAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/MissingTypeIdPropertyAnalyzerTests.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class MissingTypeIdPropertyAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+using System.Collections.Generic;
+
+namespace FourSer.Contracts
+{
+    public enum PolymorphicMode { None, SingleTypeId, IndividualTypeIds }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public PolymorphicMode PolymorphicMode { get; set; } = PolymorphicMode.None;
+        public string TypeIdProperty { get; set; }
+    }
+}";
+
+        [Fact]
+        public async Task SingleTypeId_WithTypeIdProperty_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+class MyData { [SerializeCollection(PolymorphicMode = PolymorphicMode.SingleTypeId, TypeIdProperty = ""P"")] public List<int> L {get;set;} public int P {get;set;} }";
+            await new CSharpAnalyzerTest<MissingTypeIdPropertyAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task SingleTypeId_WithoutTypeIdProperty_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+class MyData { [{|FS0014:SerializeCollection(PolymorphicMode = PolymorphicMode.SingleTypeId)|}] public List<int> L {get;set;} }";
+            await new CSharpAnalyzerTest<MissingTypeIdPropertyAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task NotSingleTypeId_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+using System.Collections.Generic;
+class MyData { [SerializeCollection(PolymorphicMode = PolymorphicMode.IndividualTypeIds)] public List<int> L {get;set;} }";
+            await new CSharpAnalyzerTest<MissingTypeIdPropertyAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/MutuallyExclusiveCollectionSizeAnalyzerTests.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers.Test/MutuallyExclusiveCollectionSizeAnalyzerTests.cs
@@ -1,0 +1,103 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace FourSer.Analyzers.Test
+{
+    public class MutuallyExclusiveCollectionSizeAnalyzerTests
+    {
+        private const string AttributeSource = @"
+using System;
+using System.Collections.Generic;
+
+namespace FourSer.Contracts
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializeCollectionAttribute : Attribute
+    {
+        public int CountSize { get; set; } = -1;
+        public string CountSizeReference { get; set; }
+        public bool Unlimited { get; set; }
+    }
+}";
+
+        [Fact]
+        public async Task OnlyCountSize_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [SerializeCollection(CountSize = 10)] public int[] MyList { get; set; } }";
+            await new CSharpAnalyzerTest<MutuallyExclusiveCollectionSizeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task OnlyCountSizeReference_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [SerializeCollection(CountSizeReference = ""C"")] public int[] MyList { get; set; } public int C {get;set;} }";
+            await new CSharpAnalyzerTest<MutuallyExclusiveCollectionSizeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task OnlyUnlimited_NoDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [SerializeCollection(Unlimited = true)] public int[] MyList { get; set; } }";
+            await new CSharpAnalyzerTest<MutuallyExclusiveCollectionSizeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task CountSizeAndCountSizeReference_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [{|FS0011:SerializeCollection(CountSize = 10, CountSizeReference = ""C"")|}] public int[] MyList { get; set; } public int C {get;set;} }";
+            await new CSharpAnalyzerTest<MutuallyExclusiveCollectionSizeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task CountSizeAndUnlimited_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [{|FS0011:SerializeCollection(CountSize = 10, Unlimited = true)|}] public int[] MyList { get; set; } }";
+            await new CSharpAnalyzerTest<MutuallyExclusiveCollectionSizeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task AllThree_ReportsDiagnostic()
+        {
+            var testCode = @"
+using FourSer.Contracts;
+class MyData { [{|FS0011:SerializeCollection(CountSize = 10, CountSizeReference = ""C"", Unlimited = true)|}] public int[] MyList { get; set; } public int C {get;set;} }";
+            await new CSharpAnalyzerTest<MutuallyExclusiveCollectionSizeAnalyzer, DefaultVerifier>
+            {
+                TestState = { Sources = { AttributeSource, testCode } },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/CountSizeReferenceExistenceAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/CountSizeReferenceExistenceAnalyzer.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CountSizeReferenceExistenceAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0006";
+
+        private static readonly LocalizableString Title = "Non-existent CountSizeReference property";
+        private static readonly LocalizableString MessageFormat = "The property '{0}' specified in CountSizeReference does not exist on type '{1}'";
+        private static readonly LocalizableString Description = "The property specified in the CountSizeReference argument of the SerializeCollection attribute must exist on the containing type.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute == null)
+            {
+                return;
+            }
+
+            var countSizeReferenceArgument = serializeCollectionAttribute.NamedArguments
+                .FirstOrDefault(arg => arg.Key == "CountSizeReference");
+
+            if (countSizeReferenceArgument.Key == null)
+            {
+                // The argument is not present, so there's nothing to check.
+                return;
+            }
+
+            var referencedPropertyName = countSizeReferenceArgument.Value.Value as string;
+            if (string.IsNullOrEmpty(referencedPropertyName))
+            {
+                // The argument is empty, which is not valid, but a different analyzer might handle this.
+                // For now, we only care if it points to a non-existent property.
+                return;
+            }
+
+            var containingType = symbol.ContainingType;
+            var referencedProperty = containingType.GetMembers(referencedPropertyName).FirstOrDefault();
+
+            if (referencedProperty == null)
+            {
+                var diagnostic = Diagnostic.Create(Rule, symbol.Locations[0], referencedPropertyName, containingType.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/CountSizeReferenceTypeAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/CountSizeReferenceTypeAnalyzer.cs
@@ -1,0 +1,105 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CountSizeReferenceTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0007";
+
+        private static readonly LocalizableString Title = "Invalid CountSizeReference property type";
+        private static readonly LocalizableString MessageFormat = "The property '{0}' specified in CountSizeReference must be an integer type, but its type is '{1}'";
+        private static readonly LocalizableString Description = "The property specified in the CountSizeReference argument of the SerializeCollection attribute must be of an integer type.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute == null)
+            {
+                return;
+            }
+
+            var countSizeReferenceArgument = serializeCollectionAttribute.NamedArguments
+                .FirstOrDefault(arg => arg.Key == "CountSizeReference");
+
+            if (countSizeReferenceArgument.Key == null)
+            {
+                return;
+            }
+
+            var referencedPropertyName = countSizeReferenceArgument.Value.Value as string;
+            if (string.IsNullOrEmpty(referencedPropertyName))
+            {
+                return;
+            }
+
+            var containingType = symbol.ContainingType;
+            var referencedMember = containingType.GetMembers(referencedPropertyName).FirstOrDefault();
+
+            if (referencedMember == null)
+            {
+                // This is handled by the CountSizeReferenceExistenceAnalyzer.
+                return;
+            }
+
+            ITypeSymbol? referencedType = null;
+            if (referencedMember is IPropertySymbol propertySymbol)
+            {
+                referencedType = propertySymbol.Type;
+            }
+            else if (referencedMember is IFieldSymbol fieldSymbol)
+            {
+                referencedType = fieldSymbol.Type;
+            }
+
+            if (referencedType != null && !IsIntegerType(referencedType))
+            {
+                var diagnostic = Diagnostic.Create(Rule, referencedMember.Locations[0], referencedPropertyName, referencedType.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private static bool IsIntegerType(ITypeSymbol type)
+        {
+            return type.SpecialType switch
+            {
+                SpecialType.System_Byte => true,
+                SpecialType.System_SByte => true,
+                SpecialType.System_Int16 => true,
+                SpecialType.System_UInt16 => true,
+                SpecialType.System_Int32 => true,
+                SpecialType.System_UInt32 => true,
+                SpecialType.System_Int64 => true,
+                SpecialType.System_UInt64 => true,
+                _ => false,
+            };
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/DuplicatePolymorphicTypeIdAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/DuplicatePolymorphicTypeIdAnalyzer.cs
@@ -1,0 +1,69 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DuplicatePolymorphicTypeIdAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0010";
+
+        private static readonly LocalizableString Title = "Duplicate polymorphic TypeId";
+        private static readonly LocalizableString MessageFormat = "The TypeId '{0}' is used more than once. Polymorphic option TypeIds must be unique for a given member.";
+        private static readonly LocalizableString Description = "All [PolymorphicOption] attributes on a single member must have unique TypeIds.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var polymorphicOptionAttributes = symbol.GetAttributes()
+                .Where(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.PolymorphicOptionAttribute")
+                .ToList();
+
+            if (polymorphicOptionAttributes.Count < 2)
+            {
+                return;
+            }
+
+            var seenTypeIds = new HashSet<object?>();
+            foreach (var attribute in polymorphicOptionAttributes)
+            {
+                if (attribute.ConstructorArguments.Length > 0)
+                {
+                    var typeIdArgument = attribute.ConstructorArguments[0];
+                    if (typeIdArgument.Value != null)
+                    {
+                        if (!seenTypeIds.Add(typeIdArgument.Value))
+                        {
+                            var diagnostic = Diagnostic.Create(Rule, attribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), typeIdArgument.Value);
+                            context.ReportDiagnostic(diagnostic);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/IncompatibleTypeAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/IncompatibleTypeAnalyzer.cs
@@ -71,19 +71,31 @@ namespace FourSer.Analyzers
                 return true;
             }
 
+            if (type.GetAttributes().Any(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.GenerateSerializerAttribute"))
+            {
+                return true;
+            }
+
             if (type.AllInterfaces.Any(i => i.ToDisplayString().StartsWith("FourSer.Contracts.ISerializable")))
             {
                 return true;
             }
 
+            // Check for collection types
+            var ienumerable_t = type.AllInterfaces.FirstOrDefault(i => i.IsGenericType && i.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>");
+            if (type is INamedTypeSymbol namedType && namedType.IsGenericType && namedType.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>")
+            {
+                ienumerable_t = namedType;
+            }
+
+            if (ienumerable_t != null)
+            {
+                return IsSerializable(ienumerable_t.TypeArguments.First());
+            }
+
             if (type is IArrayTypeSymbol arrayType)
             {
                 return IsSerializable(arrayType.ElementType);
-            }
-
-            if (type is INamedTypeSymbol namedType && namedType.IsGenericType && namedType.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.List<T>")
-            {
-                return IsSerializable(namedType.TypeArguments.First());
             }
 
             return false;

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidCountTypeAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidCountTypeAnalyzer.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class InvalidCountTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0012";
+
+        private static readonly LocalizableString Title = "Invalid CountType";
+        private static readonly LocalizableString MessageFormat = "The type '{0}' specified in CountType is not a valid integer type.";
+        private static readonly LocalizableString Description = "The type provided to the CountType property of the [SerializeCollection] attribute must be an integer type.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute == null)
+            {
+                return;
+            }
+
+            var countTypeArgument = serializeCollectionAttribute.NamedArguments
+                .FirstOrDefault(arg => arg.Key == "CountType");
+
+            if (countTypeArgument.Key == null)
+            {
+                return;
+            }
+
+            if (countTypeArgument.Value.Value is ITypeSymbol countType)
+            {
+                if (!IsIntegerType(countType))
+                {
+                    var diagnostic = Diagnostic.Create(Rule, serializeCollectionAttribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), countType.Name);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        private static bool IsIntegerType(ITypeSymbol type)
+        {
+            return type.SpecialType switch
+            {
+                SpecialType.System_Byte => true,
+                SpecialType.System_SByte => true,
+                SpecialType.System_Int16 => true,
+                SpecialType.System_UInt16 => true,
+                SpecialType.System_Int32 => true,
+                SpecialType.System_UInt32 => true,
+                SpecialType.System_Int64 => true,
+                SpecialType.System_UInt64 => true,
+                _ => false,
+            };
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidPolymorphicOptionContextAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidPolymorphicOptionContextAnalyzer.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class InvalidPolymorphicOptionContextAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0008";
+
+        private static readonly LocalizableString Title = "Invalid [PolymorphicOption] context";
+        private static readonly LocalizableString MessageFormat = "The [PolymorphicOption] attribute is used without a valid polymorphic context. Apply either [SerializePolymorphic] or [SerializeCollection(PolymorphicMode = ...)] to the member '{0}'.";
+        private static readonly LocalizableString Description = "The [PolymorphicOption] attribute can only be used on members that are also marked for polymorphic serialization.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var polymorphicOptionAttributes = symbol.GetAttributes()
+                .Where(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.PolymorphicOptionAttribute")
+                .ToList();
+
+            if (polymorphicOptionAttributes.Count == 0)
+            {
+                return;
+            }
+
+            // Check for [SerializePolymorphic]
+            var hasSerializePolymorphic = symbol.GetAttributes()
+                .Any(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializePolymorphicAttribute");
+
+            if (hasSerializePolymorphic)
+            {
+                return;
+            }
+
+            // Check for [SerializeCollection(PolymorphicMode = ...)]
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute != null)
+            {
+                var polymorphicModeArgument = serializeCollectionAttribute.NamedArguments
+                    .FirstOrDefault(arg => arg.Key == "PolymorphicMode");
+
+                if (polymorphicModeArgument.Key != null)
+                {
+                    // The enum value for None is 0.
+                    if (polymorphicModeArgument.Value.Value is int mode && mode != 0)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            // If we reach here, there's no valid context for [PolymorphicOption]
+            var diagnostic = Diagnostic.Create(Rule, symbol.Locations[0], symbol.Name);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidPolymorphicTypeAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidPolymorphicTypeAnalyzer.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class InvalidPolymorphicTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public const string AssignabilityDiagnosticId = "FS0009";
+        public const string SerializableDiagnosticId = "FS0016";
+
+        private static readonly LocalizableString AssignabilityTitle = "Invalid polymorphic option type";
+        private static readonly LocalizableString AssignabilityMessageFormat = "The type '{0}' specified in [PolymorphicOption] is not assignable to the member's type '{1}'";
+        private static readonly LocalizableString AssignabilityDescription = "The type specified in a [PolymorphicOption] attribute must be assignable to the type of the member it decorates.";
+
+        private static readonly LocalizableString SerializableTitle = "Non-serializable polymorphic option type";
+        private static readonly LocalizableString SerializableMessageFormat = "The type '{0}' specified in [PolymorphicOption] must be marked with [GenerateSerializer]";
+        private static readonly LocalizableString SerializableDescription = "The type specified in a [PolymorphicOption] attribute must be a serializable type.";
+
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor AssignabilityRule = new DiagnosticDescriptor(
+            AssignabilityDiagnosticId,
+            AssignabilityTitle,
+            AssignabilityMessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: AssignabilityDescription);
+
+        internal static readonly DiagnosticDescriptor SerializableRule = new DiagnosticDescriptor(
+            SerializableDiagnosticId,
+            SerializableTitle,
+            SerializableMessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: SerializableDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(AssignabilityRule, SerializableRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var polymorphicOptionAttributes = symbol.GetAttributes()
+                .Where(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.PolymorphicOptionAttribute")
+                .ToList();
+
+            if (polymorphicOptionAttributes.Count == 0)
+            {
+                return;
+            }
+
+            ITypeSymbol? memberType = null;
+            if (symbol is IPropertySymbol propertySymbol)
+            {
+                memberType = propertySymbol.Type;
+            }
+            else if (symbol is IFieldSymbol fieldSymbol)
+            {
+                memberType = fieldSymbol.Type;
+            }
+
+            if (memberType == null)
+            {
+                return;
+            }
+
+            foreach (var attribute in polymorphicOptionAttributes)
+            {
+                if (attribute.ConstructorArguments.Length < 2) continue;
+
+                if (attribute.ConstructorArguments[1].Value is ITypeSymbol attributeType)
+                {
+                    // Check for assignability
+                    if (!IsAssignable(attributeType, memberType))
+                    {
+                        var diagnostic = Diagnostic.Create(AssignabilityRule, attribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), attributeType.Name, memberType.Name);
+                        context.ReportDiagnostic(diagnostic);
+                    }
+
+                    // Check for [GenerateSerializer]
+                    var hasGenerateSerializer = attributeType.GetAttributes()
+                        .Any(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.GenerateSerializerAttribute");
+                    if (!hasGenerateSerializer)
+                    {
+                        var diagnostic = Diagnostic.Create(SerializableRule, attribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), attributeType.Name);
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+
+        private static bool IsAssignable(ITypeSymbol fromType, ITypeSymbol toType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(fromType, toType))
+            {
+                return true;
+            }
+
+            if (toType.TypeKind == TypeKind.Interface)
+            {
+                return fromType.AllInterfaces.Contains(toType, SymbolEqualityComparer.Default);
+            }
+
+            var baseType = fromType.BaseType;
+            while (baseType != null)
+            {
+                if (SymbolEqualityComparer.Default.Equals(baseType, toType))
+                {
+                    return true;
+                }
+                baseType = baseType.BaseType;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidSerializeCollectionTargetAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidSerializeCollectionTargetAnalyzer.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class InvalidSerializeCollectionTargetAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0005";
+
+        private static readonly LocalizableString Title = "Invalid SerializeCollection attribute target";
+        private static readonly LocalizableString MessageFormat = "The [SerializeCollection] attribute can only be applied to collection types, but it is used on type '{0}'";
+        private static readonly LocalizableString Description = "The [SerializeCollection] attribute is intended for collection types only. Applying it to non-collection types can lead to unexpected behavior.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute == null)
+            {
+                return;
+            }
+
+            ITypeSymbol? memberType = null;
+            if (symbol is IPropertySymbol propertySymbol)
+            {
+                memberType = propertySymbol.Type;
+            }
+            else if (symbol is IFieldSymbol fieldSymbol)
+            {
+                memberType = fieldSymbol.Type;
+            }
+
+            if (memberType != null && !IsCollectionType(memberType, context.Compilation))
+            {
+                var diagnostic = Diagnostic.Create(Rule, symbol.Locations[0], memberType.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private static bool IsCollectionType(ITypeSymbol type, Compilation compilation)
+        {
+            if (type.SpecialType == SpecialType.System_String)
+            {
+                return false;
+            }
+
+            var ienumerableType = compilation.GetTypeByMetadataName("System.Collections.IEnumerable");
+            if (ienumerableType == null)
+            {
+                // Should not happen in a valid compilation
+                return false;
+            }
+
+            return type.AllInterfaces.Contains(ienumerableType, SymbolEqualityComparer.Default);
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidTypeIdTypeAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/InvalidTypeIdTypeAnalyzer.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class InvalidTypeIdTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0013";
+
+        private static readonly LocalizableString Title = "Invalid TypeIdType";
+        private static readonly LocalizableString MessageFormat = "The type '{0}' specified in TypeIdType is not a valid integer or enum type.";
+        private static readonly LocalizableString Description = "The type provided to the TypeIdType property must be an integer or an enum type.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+            var attributes = symbol.GetAttributes();
+
+            var serializePolymorphicAttribute = attributes.FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializePolymorphicAttribute");
+            var serializeCollectionAttribute = attributes.FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            AttributeData? attribute = serializePolymorphicAttribute ?? serializeCollectionAttribute;
+
+            if (attribute == null)
+            {
+                return;
+            }
+
+            var typeIdTypeArgument = attribute.NamedArguments.FirstOrDefault(arg => arg.Key == "TypeIdType");
+
+            if (typeIdTypeArgument.Key == null)
+            {
+                return;
+            }
+
+            if (typeIdTypeArgument.Value.Value is ITypeSymbol typeIdType)
+            {
+                if (!IsValidTypeIdType(typeIdType))
+                {
+                    var diagnostic = Diagnostic.Create(Rule, attribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), typeIdType.Name);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        private static bool IsValidTypeIdType(ITypeSymbol type)
+        {
+            if (type.TypeKind == TypeKind.Enum)
+            {
+                return true;
+            }
+
+            return type.SpecialType switch
+            {
+                SpecialType.System_Byte => true,
+                SpecialType.System_SByte => true,
+                SpecialType.System_Int16 => true,
+                SpecialType.System_UInt16 => true,
+                SpecialType.System_Int32 => true,
+                SpecialType.System_UInt32 => true,
+                SpecialType.System_Int64 => true,
+                SpecialType.System_UInt64 => true,
+                _ => false,
+            };
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/MismatchedTypeIdPropertyTypeAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/MismatchedTypeIdPropertyTypeAnalyzer.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MismatchedTypeIdPropertyTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0015";
+
+        private static readonly LocalizableString Title = "Mismatched TypeIdProperty type";
+        private static readonly LocalizableString MessageFormat = "The type of the TypeIdProperty '{0}' is '{1}', which does not match the expected TypeIdType '{2}'.";
+        private static readonly LocalizableString Description = "The type of the property specified in TypeIdProperty must match the type specified in TypeIdType.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute == null)
+            {
+                return;
+            }
+
+            var polymorphicModeArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "PolymorphicMode");
+            if (polymorphicModeArg.Key == null || polymorphicModeArg.Value.Value is not int mode || mode != 1) // SingleTypeId
+            {
+                return;
+            }
+
+            var typeIdPropertyArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "TypeIdProperty");
+            if (typeIdPropertyArg.Key == null || typeIdPropertyArg.Value.Value is not string propertyName || string.IsNullOrEmpty(propertyName))
+            {
+                return; // Handled by MissingTypeIdPropertyAnalyzer
+            }
+
+            var containingType = symbol.ContainingType;
+            var typeIdProperty = containingType.GetMembers(propertyName).FirstOrDefault();
+            if (typeIdProperty == null)
+            {
+                return; // Handled by a different analyzer (FS0006 for CountSizeReference, could be a new one for this)
+            }
+
+            ITypeSymbol? actualPropertyType = null;
+            if (typeIdProperty is IPropertySymbol propertySymbol)
+            {
+                actualPropertyType = propertySymbol.Type;
+            }
+            else if (typeIdProperty is IFieldSymbol fieldSymbol)
+            {
+                actualPropertyType = fieldSymbol.Type;
+            }
+
+            if (actualPropertyType == null)
+            {
+                return;
+            }
+
+            var typeIdTypeArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "TypeIdType");
+            ITypeSymbol expectedTypeIdType = context.Compilation.GetSpecialType(SpecialType.System_Int32); // Default
+            if (typeIdTypeArg.Key != null && typeIdTypeArg.Value.Value is ITypeSymbol specifiedType)
+            {
+                expectedTypeIdType = specifiedType;
+            }
+
+            if (!SymbolEqualityComparer.Default.Equals(actualPropertyType, expectedTypeIdType))
+            {
+                var diagnostic = Diagnostic.Create(Rule, typeIdProperty.Locations[0], propertyName, actualPropertyType.Name, expectedTypeIdType.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/MissingTypeIdPropertyAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/MissingTypeIdPropertyAnalyzer.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MissingTypeIdPropertyAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0014";
+
+        private static readonly LocalizableString Title = "Missing TypeIdProperty";
+        private static readonly LocalizableString MessageFormat = "The 'TypeIdProperty' must be set when using PolymorphicMode.SingleTypeId.";
+        private static readonly LocalizableString Description = "When PolymorphicMode is set to SingleTypeId, the TypeIdProperty must be specified to identify the property that holds the type ID for the collection.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute == null)
+            {
+                return;
+            }
+
+            var polymorphicModeArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "PolymorphicMode");
+            if (polymorphicModeArg.Key == null)
+            {
+                return;
+            }
+
+            // PolymorphicMode.SingleTypeId has a value of 1 in the enum.
+            if (polymorphicModeArg.Value.Value is int mode && mode == 1)
+            {
+                var typeIdPropertyArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "TypeIdProperty");
+                if (typeIdPropertyArg.Key == null || typeIdPropertyArg.Value.Value is not string value || string.IsNullOrEmpty(value))
+                {
+                    var diagnostic = Diagnostic.Create(Rule, serializeCollectionAttribute.ApplicationSyntaxReference!.GetSyntax().GetLocation());
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+    }
+}

--- a/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/MutuallyExclusiveCollectionSizeAnalyzer.cs
+++ b/src/FourSer.Analyzers/FourSer.Analyzers/FourSer.Analyzers/MutuallyExclusiveCollectionSizeAnalyzer.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FourSer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MutuallyExclusiveCollectionSizeAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "FS0011";
+
+        private static readonly LocalizableString Title = "Mutually exclusive collection size attributes";
+        private static readonly LocalizableString MessageFormat = "The collection size attributes 'CountSize', 'CountSizeReference', and 'Unlimited' are mutually exclusive. Only one can be used at a time.";
+        private static readonly LocalizableString Description = "The 'CountSize', 'CountSizeReference', and 'Unlimited' properties on the [SerializeCollection] attribute cannot be used together.";
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property, SymbolKind.Field);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            var serializeCollectionAttribute = symbol.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "FourSer.Contracts.SerializeCollectionAttribute");
+
+            if (serializeCollectionAttribute == null)
+            {
+                return;
+            }
+
+            int setCount = 0;
+
+            var countSizeArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "CountSize");
+            if (countSizeArg.Key != null && countSizeArg.Value.Value is int countSize && countSize != -1)
+            {
+                setCount++;
+            }
+
+            var countSizeRefArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "CountSizeReference");
+            if (countSizeRefArg.Key != null && countSizeRefArg.Value.Value is string)
+            {
+                setCount++;
+            }
+
+            var unlimitedArg = serializeCollectionAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "Unlimited");
+            if (unlimitedArg.Key != null && unlimitedArg.Value.Value is bool unlimited && unlimited)
+            {
+                setCount++;
+            }
+
+            if (setCount > 1)
+            {
+                var diagnostic = Diagnostic.Create(Rule, serializeCollectionAttribute.ApplicationSyntaxReference!.GetSyntax().GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the final suite of Roslyn analyzers to the `FourSer.Analyzers` project, providing comprehensive validation for the serialization attributes.

New Analyzers:
- `InvalidTypeIdTypeAnalyzer` (FS0013): Ensures `TypeIdType` is a valid integer or enum.
- `MissingTypeIdPropertyAnalyzer` (FS0014): Ensures `TypeIdProperty` is set when required.
- `MismatchedTypeIdPropertyTypeAnalyzer` (FS0015): Verifies that the type of `TypeIdProperty` matches `TypeIdType`.

Updated Analyzer:
- `InvalidPolymorphicTypeAnalyzer` (FS0009 & FS0016): Now also checks that a type in `[PolymorphicOption]` is marked with `[GenerateSerializer]`.

Unit tests have been added and updated for all new and modified analyzers.